### PR TITLE
Allow script runs from any pwd; make script idempotent

### DIFF
--- a/bin/patch-enzyme.sh
+++ b/bin/patch-enzyme.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
 echo "Patching enzyme dependency for Context fix"
-(cd ../../; patch -p1 < node_modules/enzyme-context-patch/patches/enzyme-adapter-react-16+1.1.1.patch)
+SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
+PACKAGEPATH="$( dirname $SCRIPTPATH )/../../"
+(cd $PACKAGEPATH; patch -N -r - -p1 < node_modules/enzyme-context-patch/patches/enzyme-adapter-react-16+1.1.1.patch)


### PR DESCRIPTION
It seems that yarn sometimes reinstalls enzyme and this package's postinstall script doesn't get rerun. 

This change changes two thing:
- The bash script can now be run from any directory, i.e., `./node_modules/.bin/enzyme-context-patch` or `./node_modules/enzyme-context-patch/bin/patch-enzyme.sh`
- The script can now be run multiple times without it asking to reverse or reapply the patch

This allows the patch to be applied with the `test` npm script, i.e.:
```
"scripts": {
  "test": "enzyme-context-patch && jest"
}
```