### PR TITLE
Support for windows (with bash)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "KevinGrandon/enzyme-react-16-context-patch",
   "bin": "bin/patch-enzyme.sh",
   "scripts": {
-    "postinstall": "echo 'Patching from postinstall.' && bin/patch-enzyme.sh"
+    "postinstall": "echo 'Patching from postinstall.' && bash bin/patch-enzyme.sh"
   },
   "peerDependencies": {
     "enzyme": "^3.3.0"


### PR DESCRIPTION
Fix error "'bin' is not recognized as an internal or external command" on windows
Support only for windows with bash (via git, mingw32, linux on windows, etc.)